### PR TITLE
add-item-display

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.all.order(id: "DESC")
   end
 
   def new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -76,33 +76,21 @@
     %h2.title ピックアップカテゴリー
     = link_to '新規投稿商品', "#", class: "subtitle"
     %ul.item-lists
-      %li.list
-        = link_to "#" do
+      - @items.each do |item|
+        %li.list
+          = link_to ""
           .item-img-content
-            = image_tag "item-sample.png", class: "item-img"
-            .sold-out
-              %span Sold Out!!
+            = image_tag item.image, class: "item-img"
+            - if item.user_id = nil
+              .sold-out
+                %span Sold Out!!
           .item-info
             %h3.item-name
-              = "商品名"
+              = item.name
             .item-price
               %span
-                = "販売価格"
+                = item.price
                 円
-                %br>/
-                (税込み)
-              .star-btn
-                = image_tag "star.png", class:"star-icon"
-                %span.star-count 0
-      %li.list
-        = link_to '#' do
-          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
-          .item-info
-            %h3.item-name
-              商品を出品してね！
-            .item-price
-              %span
-                99999999円
                 %br>/
                 (税込み)
               .star-btn

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_085307) do
+ActiveRecord::Schema.define(version: 2020_07_31_054839) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
# What
商品一覧表示機能を実装した。itemコントローラーのindexメソッド内でitemを全て呼び出すように記述し、ビューを対応させた。

# Why
出品した商品を全ユーザー（登録していないユーザー含む）が確認できるようにするため。