### PR TITLE
add-item-show

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show]
+
   def index
     @items = Item.all.order(id: "DESC")
   end
@@ -16,9 +18,16 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:image, :name, :detail, :category_id, :condition_id, :postage_payer_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,7 +119,7 @@
 
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "" %>
+        <%= link_to(item_path(item.id)) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -141,6 +141,7 @@
             </div>
           </div>
         </div>
+        <% end %>
       </li>
     <% end %>
     </ul>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,30 +3,32 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: "item-box-img" %>
+
       <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+       </div>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-
+  <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+  <% elsif user_signed_in? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-
+  <% end %>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -34,27 +36,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage_payer.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
商品詳細表示機能の実装をした。コントローラーにprivateメソッドを追加し、findメソッドでitemのidを拾うように設定し、ビューを出品者の場合、閲覧者の場合に分けた。

# Why
出品者は購入が、閲覧者は商品情報の編集、削除ができないようにするため。
