### PR TITLE
add-price-jquery

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 // require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("../price");
 require("../card");
 
 

--- a/app/javascript/price.js
+++ b/app/javascript/price.js
@@ -1,0 +1,15 @@
+$(function(){  
+  $('.price-input').on('keyup', function(){
+    var data = $(this).val();
+    var profit = Math.round(data * 0.9)
+    var fee = (data - profit)
+    $('#add-tax-price').html(fee)
+    $('#add-tax-price').prepend('¥')
+    $('#profit').html(profit)
+    $('#profit').prepend('¥')
+    if(profit == '') {
+    $('#add-tax-price').html('');
+    $('#profit').html('');
+    }
+  })
+ }) 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>Furima</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
# What
jqueryを使った簡易計算機能の実装。
jQueryを導入し、新たに作成したjsファイルに記述していった。

# Why
販売価格によって、手数料と利益を非同期で変化させるため。